### PR TITLE
Brew update before install

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -156,6 +156,7 @@ jobs:
           pwd
           uname -a
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+          brew update
           brew install git ccache ninja libtool gettext llvm@15 gcc binutils grep findutils zstd
           export PATH=$(brew --prefix llvm@15)/bin:$PATH
           which clang++
@@ -269,6 +270,7 @@ jobs:
           pwd
           uname -a
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+          brew update
           brew install git ccache ninja libtool gettext llvm@15 gcc binutils grep findutils zstd
           export PATH=$(brew --prefix llvm@15)/bin:$PATH
           which clang++

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -72,7 +72,6 @@ jobs:
         with:
           key: ${{ matrix.os }}
           max-size: 5G
-          append-timestamp: true
       - name: remove old clang and link clang-15 to clang
         if: matrix.os == 'ubuntu-20.04'
         run: |
@@ -190,7 +189,6 @@ jobs:
         with:
           key: ${{ matrix.os }}
           max-size: 5G
-          append-timestamp: true
       - name: Run chdb/build.sh
         timeout-minutes: 300
         run: |
@@ -303,7 +301,6 @@ jobs:
         with:
           key: ${{ matrix.os }}
           max-size: 5G
-          append-timestamp: true
       - name: Prepare chdb/build.sh
         run: |
           python3 -m pip install pybind11

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           key: ${{ matrix.os }}
           max-size: 5G
+          append-timestamp: false
       - name: remove old clang and link clang-15 to clang
         if: matrix.os == 'ubuntu-20.04'
         run: |
@@ -189,6 +190,7 @@ jobs:
         with:
           key: ${{ matrix.os }}
           max-size: 5G
+          append-timestamp: false
       - name: Run chdb/build.sh
         timeout-minutes: 300
         run: |
@@ -301,6 +303,7 @@ jobs:
         with:
           key: ${{ matrix.os }}
           max-size: 5G
+          append-timestamp: false
       - name: Prepare chdb/build.sh
         run: |
           python3 -m pip install pybind11


### PR DESCRIPTION


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Although we lock llvm@15, different github action runner may have llvm 15.0.7 or 15.0.7_1. This will cause ccache miss a lot. Hope brew update will keep llvm latest

