### PR TITLE
Add function: chdb() to return version

### DIFF
--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -121,3 +121,7 @@ else()
     add_library(clickhouse_functions SHARED ${OBJECT_LIBS})
     target_link_libraries(clickhouse_functions PUBLIC ${PUBLIC_LIBS} PRIVATE ${PRIVATE_LIBS})
 endif ()
+
+if (CHDB_VERSION)
+    add_compile_definitions(CHDB_VERSION_STRING=${CHDB_VERSION})
+endif ()

--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -123,5 +123,5 @@ else()
 endif ()
 
 if (CHDB_VERSION)
-    add_compile_definitions(CHDB_VERSION_STRING=${CHDB_VERSION})
+    add_compile_definitions(CHDB_VERSION_STRING="${CHDB_VERSION}")
 endif ()

--- a/src/Functions/chdbVersion.cpp
+++ b/src/Functions/chdbVersion.cpp
@@ -1,0 +1,33 @@
+#include <DataTypes/DataTypeString.h>
+#include <Functions/FunctionFactory.h>
+
+namespace DB
+{
+
+namespace
+{
+    /// chdb() - returns the current chdb version as a string.
+    class FunctionChdbVersion : public FunctionConstantBase<FunctionChdbVersion, String, DataTypeString>
+    {
+    public:
+        static constexpr auto name = "chdb";
+        static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionChdbVersion>(context); }
+        explicit FunctionChdbVersion(ContextPtr context) : FunctionConstantBase(CHDB_VERSION_STRING, context->isDistributed()) {}
+    };
+}
+  
+#if defined(CHDB_VERSION_STRING)
+REGISTER_FUNCTION(ChdbVersion)
+{
+    factory.registerFunction<FunctionChdbVersion>(
+        {
+        R"(
+Returns the version of chDB.  The result type is String.
+        )",
+        Documentation::Examples{{"chdb", "SELECT chdb()"}},
+        Documentation::Categories{"String"}
+        }, FunctionFactory::CaseInsensitive);
+}
+#endif
+
+}

--- a/src/Functions/chdbVersion.cpp
+++ b/src/Functions/chdbVersion.cpp
@@ -1,5 +1,6 @@
 #include <DataTypes/DataTypeString.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/FunctionConstantBase.h>
 
 namespace DB
 {

--- a/src/Functions/chdbVersion.cpp
+++ b/src/Functions/chdbVersion.cpp
@@ -1,3 +1,5 @@
+#if defined(CHDB_VERSION_STRING)
+
 #include <DataTypes/DataTypeString.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionConstantBase.h>
@@ -16,8 +18,7 @@ namespace
         explicit FunctionChdbVersion(ContextPtr context) : FunctionConstantBase(CHDB_VERSION_STRING, context->isDistributed()) {}
     };
 }
-  
-#if defined(CHDB_VERSION_STRING)
+    
 REGISTER_FUNCTION(ChdbVersion)
 {
     factory.registerFunction<FunctionChdbVersion>(
@@ -29,6 +30,5 @@ Returns the version of chDB.  The result type is String.
         Documentation::Categories{"String"}
         }, FunctionFactory::CaseInsensitive);
 }
-#endif
-
 }
+#endif


### PR DESCRIPTION
This PR adds a simple `chdb()` function with no parameters that returns the current version of chDB as a string. 
The version number is defined using the `CHDB_VERSION` macro, which should be defined during the build process.

The function is conditionally compiled using an `#if` directive that checks whether the `CHDB_VERSION_STRING` macro derived from `CHDB_VERSION` is defined, to avoid building and registering the function if the version number is not available.

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
add function `chdb()` returning the current build version
